### PR TITLE
fix:ログイン中の元気からのバッドステータスへ変更時のモーションの切り替え対応

### DIFF
--- a/app/api/petStatDecrease.ts
+++ b/app/api/petStatDecrease.ts
@@ -1,6 +1,21 @@
+import { getPetDetails } from './getPetDetails';
+
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-export const petStatDecrease = async (): Promise<void> => {
+interface PetDetails {
+  id: number;
+  name: string;
+  breed: string;
+  level: number;
+  experience: number;
+  physical: number;
+  satiety: number;
+  happiness: number;
+  states: number;
+  offspring_count: number;
+}
+
+export const petStatDecrease = async (setPetDetails: React.Dispatch<React.SetStateAction<PetDetails | null>>): Promise<void> => {
   try {
     const response = await fetch(`${API_BASE_URL}/pet_stat_decrease`, {
       method: 'POST',
@@ -18,6 +33,10 @@ export const petStatDecrease = async (): Promise<void> => {
     }
 
     console.log('Pet stats decreased successfully');
+
+    // 最新のペット情報を取得して状態を更新
+    const updatedPetDetails = await getPetDetails();
+    setPetDetails(updatedPetDetails);
   } catch (error) {
     console.error('Error decreasing pet stats:', error);
   }

--- a/app/main/page.tsx
+++ b/app/main/page.tsx
@@ -181,7 +181,7 @@ export default function Main() {
       setPhysicalRecoveryIntervalId(physicalInterval);
   
       const statDecreaseInterval = setInterval(() => {
-        petStatDecrease(); // 満腹度と幸福度の減少 (10分ごと)
+        petStatDecrease(setPetDetails); // 満腹度と幸福度の減少 (10分ごと)
       }, 600000);
       setStatDecreaseIntervalId(statDecreaseInterval);
   


### PR DESCRIPTION
- [ ] ログイン中の時間経過によるステータス変更は```app/api/petStatDecrease.ts```に依存しているため、```getPetDetails()```を実行しモーションをリアルタイムで切り替えるように変更