### PR TITLE
Feature/issue171

### DIFF
--- a/app/kiyaku/page.tsx
+++ b/app/kiyaku/page.tsx
@@ -3,6 +3,8 @@
 import React from 'react';
 import { Box, Typography } from '@mui/material';
 
+import BackButton from '../../components/atoms/BackButton';
+
 import { subTheme } from '../../styles/theme'
 import ThemeWrapper from '../../styles/ThemeWrapper';
 
@@ -137,6 +139,9 @@ const Kiyaku = () => {
         ユーザーは，本サービスの利用において，暴力団，暴力団関係企業，総会屋，社会運動等標榜ゴロまたは特殊知能暴力集団等その他これに準ずる者（以下「反社会的勢力」といいます。）に該当しないことを表明し，保証するものとします。当方は，ユーザーが反社会的勢力に該当することが判明した場合，直ちに本サービスの利用を停止または登録を抹消することができるものとします。
         </Typography>
         <Typography marginBottom="10vh">以上</Typography>
+        <Box width="100%" display="flex" justifyContent="flex-end" sx={{marginBottom:"100px"}}>
+          <BackButton />
+        </Box>
       </Box>
     </ThemeWrapper>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,10 +26,10 @@ export default function Home() {
           />
           <NavigationLink 
             href="/login" 
-            label="Login" 
+            label="あそぶ" 
             componentType="button" 
             color="secondary" 
-            sx={{ color: 'white' }} 
+            sx={{ color: 'white', fontSize: '20px' }} 
           />
         </Box>
       </Container>

--- a/app/privacyPolicy/page.tsx
+++ b/app/privacyPolicy/page.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import React from 'react';
+import { Box, Typography } from '@mui/material';
+
+import { subTheme } from '../../styles/theme'
+import ThemeWrapper from '../../styles/ThemeWrapper';
+
+const privacyPolicy = () => {
+  return (
+    <ThemeWrapper theme={subTheme}>
+      <Box display="flex" flexDirection="column" alignItems="center" justifyContent="center" minHeight="100vh" margin="0 20vh 0 20vh">
+        <Typography variant="h3" margin="11vh" marginBottom="3vh">プライバシーポリシー</Typography>
+
+        <Typography variant="h5" marginBottom="20px">お客様から取得する情報</Typography>
+        <Typography marginBottom="10px">当アプリでは、お客様から以下の情報を取得します。</Typography>
+        <Typography>・氏名(ニックネームやペンネームも含む)</Typography>
+        <Typography>・メールアドレス</Typography>
+        <Typography>・外部サービス連携により取得した情報（設定により制限されます）</Typography>
+        <Typography marginBottom="20px">・Cookie(クッキー)を用いて生成された識別情報</Typography>
+        
+        <Typography variant="h5" marginBottom="20px">情報の利用目的</Typography>
+        <Typography marginBottom="10px">取得した情報は、以下の目的で利用します。</Typography>
+        <Typography>・本人確認・認証</Typography>
+        <Typography>・お問い合わせへの対応</Typography>
+        <Typography marginBottom="20px">・サービス改善のための分析</Typography>
+
+        <Typography variant="h5" marginBottom="20px">第三者提供</Typography>
+        <Typography marginBottom="20px">個人情報は、ユーザーの同意なく第三者に提供しません。</Typography>
+        
+        <Typography variant="h5" marginBottom="20px">プライバシーポリシーの変更</Typography>
+        <Typography marginBottom="20px">必要に応じてプライバシーポリシーを変更する場合があります。変更内容は適切な方法で通知します。</Typography>
+        
+        <Typography variant="h5" marginBottom="20px">お問い合わせ</Typography>
+        <Typography>情報の開示・訂正・削除の希望がある場合は、下記のメールアドレスまでご連絡ください。</Typography>
+        <Typography marginBottom="100px">e-mail: rights.data9@gmail.com</Typography>
+
+      </Box>
+    </ThemeWrapper>
+  );
+};
+
+export default privacyPolicy;

--- a/app/privacyPolicy/page.tsx
+++ b/app/privacyPolicy/page.tsx
@@ -3,12 +3,14 @@
 import React from 'react';
 import { Box, Typography } from '@mui/material';
 
-import { subTheme } from '../../styles/theme'
+import BackButton from '../../components/atoms/BackButton';
+
+import { mainTheme } from '../../styles/theme'
 import ThemeWrapper from '../../styles/ThemeWrapper';
 
 const privacyPolicy = () => {
   return (
-    <ThemeWrapper theme={subTheme}>
+    <ThemeWrapper theme={mainTheme}>
       <Box display="flex" flexDirection="column" alignItems="center" justifyContent="center" minHeight="100vh" margin="0 20vh 0 20vh">
         <Typography variant="h3" margin="11vh" marginBottom="3vh">プライバシーポリシー</Typography>
 
@@ -39,6 +41,9 @@ const privacyPolicy = () => {
         <Typography>情報の開示・訂正・削除の希望がある場合は、下記のメールアドレスまでご連絡ください。</Typography>
         <Typography marginBottom="100px">e-mail: rights.data9@gmail.com</Typography>
 
+        <Box width="100%" display="flex" justifyContent="flex-end" sx={{marginBottom:"100px"}}>
+          <BackButton />
+        </Box>
       </Box>
     </ThemeWrapper>
   );

--- a/app/privacyPolicy/page.tsx
+++ b/app/privacyPolicy/page.tsx
@@ -14,16 +14,20 @@ const privacyPolicy = () => {
 
         <Typography variant="h5" marginBottom="20px">お客様から取得する情報</Typography>
         <Typography marginBottom="10px">当アプリでは、お客様から以下の情報を取得します。</Typography>
-        <Typography>・氏名(ニックネームやペンネームも含む)</Typography>
-        <Typography>・メールアドレス</Typography>
-        <Typography>・外部サービス連携により取得した情報（設定により制限されます）</Typography>
-        <Typography marginBottom="20px">・Cookie(クッキー)を用いて生成された識別情報</Typography>
+        <Typography marginBottom="20px">
+          <Typography>・氏名(ニックネームやペンネームも含む)</Typography>
+          <Typography>・メールアドレス</Typography>
+          <Typography>・外部サービス連携により取得した情報（設定により制限されます）</Typography>
+          <Typography>・Cookie(クッキー)を用いて生成された識別情報</Typography>
+        </Typography>
         
         <Typography variant="h5" marginBottom="20px">情報の利用目的</Typography>
         <Typography marginBottom="10px">取得した情報は、以下の目的で利用します。</Typography>
-        <Typography>・本人確認・認証</Typography>
-        <Typography>・お問い合わせへの対応</Typography>
-        <Typography marginBottom="20px">・サービス改善のための分析</Typography>
+        <Typography marginBottom="20px">
+          <Typography>・本人確認・認証</Typography>
+          <Typography>・お問い合わせへの対応</Typography>
+          <Typography>・サービス改善のための分析</Typography>
+        </Typography>
 
         <Typography variant="h5" marginBottom="20px">第三者提供</Typography>
         <Typography marginBottom="20px">個人情報は、ユーザーの同意なく第三者に提供しません。</Typography>

--- a/components/organisms/ClientSideComponent.tsx
+++ b/components/organisms/ClientSideComponent.tsx
@@ -8,6 +8,8 @@ import { useRouter } from 'next/router';
 import { analytics } from '../../lib/firebaseConfig'; 
 import { logEvent } from "firebase/analytics";
 
+import { StandaloneProvider } from '../../contexts/StandaloneContext';
+
 const ClientSideComponent: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const isPwa = usePwaStatus();
   const [isClient, setIsClient] = useState(false);
@@ -56,8 +58,10 @@ const ClientSideComponent: React.FC<{ children: React.ReactNode }> = ({ children
 
   return (
     <>
-      {!isPwa && <NotPwaHeader />}
-      {children}
+      <StandaloneProvider>
+        {!isPwa && <NotPwaHeader />}
+        {children}
+      </StandaloneProvider>
     </>
   );
 };

--- a/components/organisms/ClientSideComponent.tsx
+++ b/components/organisms/ClientSideComponent.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from 'react';
 import usePwaStatus from '../../hooks/app/usePwaStatus';
 import NotPwaHeader from './NotPwaHeader';
 
-import { useRouter } from 'next/router';
 import { analytics } from '../../lib/firebaseConfig'; 
 import { logEvent } from "firebase/analytics";
 

--- a/components/organisms/Footer.tsx
+++ b/components/organisms/Footer.tsx
@@ -5,6 +5,7 @@ import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import { Box } from '@mui/material';
+import { usePathname } from 'next/navigation';
 
 import NavigationLink from '../atoms/NavigationLink'
 
@@ -12,6 +13,14 @@ import { subTheme } from '../../styles/theme'
 import ThemeWrapper from '../../styles/ThemeWrapper';
 
 const Footer = () => {
+  const pathname = usePathname(); // 現在のパスを取得
+  const hideFooterPaths = ['/kiyaku', '/privacyPolicy']; // Footerを非表示にするパスを指定
+
+  // 指定されたパスの場合、Footerを非表示にする
+  if (hideFooterPaths.includes(pathname)) {
+    return null;
+  }
+
   return (
     <ThemeWrapper theme={subTheme}>
       <AppBar position="fixed" color="secondary" sx={{ top: 'auto', bottom: 0, height: '7vh' }}>

--- a/components/organisms/Footer.tsx
+++ b/components/organisms/Footer.tsx
@@ -22,7 +22,7 @@ const Footer = () => {
             </Typography>
             <Box display="flex" justifyContent="space-between" gap="20px">
               <NavigationLink href="/kiyaku" label="利用規約" componentType="link" color="primary" underline="hover" />
-              <NavigationLink href="https://kiyac.app/privacypolicy/3QB6GsYYlo7FzDYekrOB" label="プライバシーポリシー" componentType="link" color="primary" underline="hover" />
+              <NavigationLink href="/privacyPolicy" label="プライバシーポリシー" componentType="link" color="primary" underline="hover" />
               <NavigationLink href="https://docs.google.com/forms/d/e/1FAIpQLScbwBebtL1O1Oxz2XG5sX_DVSsyzQL6FDzS0gTk1p0jkSJxig/viewform?usp=sf_link" label="お問い合わせ" componentType="link" color="primary" underline="hover" />
             </Box>
           </Box>

--- a/components/organisms/NotPwaHeader.tsx
+++ b/components/organisms/NotPwaHeader.tsx
@@ -40,7 +40,7 @@ const NotPwaHeader = () => {
                   alt="Virtual Pet App ✖"
                   width={35}
                   height={35}
-                  style={{ cursor: 'pointer', transform: 'translateY(-50%)', marginTop: '50%' }}
+                  style={{ transform: 'translateY(-50%)', marginTop: '50%' }}
                 />
               </Box>
             </Box>

--- a/components/organisms/NotPwaHeader.tsx
+++ b/components/organisms/NotPwaHeader.tsx
@@ -6,12 +6,13 @@ declare global {
   }
 }
 
-import React, {useState,useEffect } from 'react';
+import React from 'react';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import { Box } from '@mui/material';
 import Image from 'next/image';
+import { usePathname } from 'next/navigation';
 
 import { subTheme } from '../../styles/theme'
 import ThemeWrapper from '../../styles/ThemeWrapper';
@@ -26,6 +27,14 @@ const NotPwaHeader = () => {
   const isStandalone = useStandalone();
   const bucketName = process.env.NEXT_PUBLIC_AWS_BUCKET_NAME;
   const region = process.env.NEXT_PUBLIC_AWS_REGION;
+
+  const pathname = usePathname(); // 現在のパスを取得
+  const hideFooterPaths = ['/kiyaku', '/privacyPolicy']; // Footerを非表示にするパスを指定
+
+  // 指定されたパスの場合、Footerを非表示にする
+  if (hideFooterPaths.includes(pathname)) {
+    return null;
+  }
 
   return (
     <ThemeWrapper theme={subTheme}>


### PR DESCRIPTION
- [ ] 外部のサイトを使用していたのを変更し、プライバシーポリシーページを作成
- [ ] プライバシーポリシーページと規約ページに戻るボタンを追加
- [ ] プライバシーポリシーページと規約ページを閲覧中の場合はFooterとNotPwaHeaderが非表示になるように設定
- [ ] バツボタンのクリック判定を削除
- [ ] PWA時のMenuのpadding出し分けについて修正
- [ ] その他スタイル調整